### PR TITLE
V10 compatibility - inline links

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -192,7 +192,7 @@
   background-color: var(--sfmod-color-background) !important;
 }
 
-.system-sfrpg a.entity-link,
+.system-sfrpg a.content-link,
 .system-sfrpg a.inline-roll {
   border: 1px solid var(--sfmod-color-primary);
   color: var(--sfmod-color-primary);
@@ -269,9 +269,9 @@
   cursor: pointer;
 }
 
-.system-sfrpg a.entity-link,
+.system-sfrpg a.content-link,
 .system-sfrpg a.inline-roll {
-  background: none;
+  background: var(--color-border-dark-1);
 }
 
 .system-sfrpg input[type="text"],
@@ -554,7 +554,7 @@ sheets borders
   flex-grow: 1;
 }
 
-.system-sfrpg a.entity-link i,
+.system-sfrpg a.content-link i,
 .system-sfrpg a.inline-roll i {
   color: unset;
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "sfrpg-modern-ui",
     "title": "Dark UI for SFRPG",
     "description": "A dark UI for SFRPG system.",
-    "version": "1.6.3",
+    "version": "1.7.0",
     "author": "Coboye",
     "authors": [
         {
@@ -13,8 +13,10 @@
     "system": [
         "sfrpg"
     ],
-    "compatibleCoreVersion": "9",
-    "minimumCoreVersion": "0.8.3",
+    "compatibility": {
+        "minimum": 10,
+        "verified": 10.285
+    },
     "styles": [
         "sfrpg-modern-ui.css"
     ],
@@ -66,7 +68,7 @@
     "bugs": "https://github.com/coboye/sfrpg-modern-ui/issues",
     "url": "https://github.com/coboye/sfrpg-modern-ui",
     "manifest": "https://raw.githubusercontent.com/coboye/sfrpg-modern-ui/main/module.json",
-    "download": "https://codeload.github.com/coboye/sfrpg-modern-ui/zip/refs/tags/release/1.6.3",
+    "download": "https://codeload.github.com/coboye/sfrpg-modern-ui/zip/refs/tags/release/1.7.0",
     "readme": "https://github.com/coboye/sfrpg-modern-ui/blob/main/README.md",
     "changelog": "https://github.com/coboye/sfrpg-modern-ui/blob/main/CHANGELOG.md",
     "flags": {


### PR DESCRIPTION
V10 changed the class name for inline links, so I adjusted the CSS accordingly. I also added a background to the links so they stand out a bit, and you don't get a line going through the bottom when they're used in headers.

I also adjusted module.json to the new V10 format. Make sure to mark 1.6.3's maximum version as V9 on the admin page so Foundry doesn't update people to 1.7.0. (As well as 1.7.0 as only compatible with V10, obviously)