### PR TITLE
Fix blockquotes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -71,10 +71,6 @@
   vertical-align: -0.4em;
 }
 
-.system-sfrpg blockquote p {
-  display: inline;
-}
-
 .sfrpg.sheet .journal-entry-content h3,
 .sfrpg.sheet .item-summary h3 {
   color: var(--sfmod-color-primary);


### PR DESCRIPTION
`display: inline` causes blockquotes to all display on one line
![image](https://user-images.githubusercontent.com/77904738/193170563-78bbbb7a-8b96-459e-96da-4d824ef2e77e.png)

Deleting this rule (and defaulting back to `block`) causes them to display as expected
![image](https://user-images.githubusercontent.com/77904738/193170708-97a8c519-df77-4186-8853-94aea49c4339.png)
